### PR TITLE
Use scale for img in obj browser and preview in popup

### DIFF
--- a/src/customizations/volto/components/manage/Sidebar/ObjectBrowserNav.jsx
+++ b/src/customizations/volto/components/manage/Sidebar/ObjectBrowserNav.jsx
@@ -74,7 +74,17 @@ const ObjectBrowserNav = ({
                 key={item['@id']}
                 content={
                   <>
-                    <Icon name={homeSVG} size="18px" />{' '}
+                    {item['@type'] === 'Image' && (
+                      <Image
+                        style={{
+                          marginLeft: 'auto',
+                          marginRight: 'auto',
+                          marginBottom: '5px',
+                        }}
+                        src={`${item?.getURL}/@@images/image/mini`}
+                      />
+                    )}
+                    <Icon name={homeSVG} size="18px" />
                     {flattenToAppURL(item['@id'])} ( {item['@type']})
                   </>
                 }
@@ -82,7 +92,7 @@ const ObjectBrowserNav = ({
                   <span>
                     {item['@type'] === 'Image' ? (
                       <Image
-                        src={`${item?.getURL}/@@images/image`}
+                        src={`${item?.getURL}/@@images/image/icon`}
                         style={{
                           marginRight: '10px',
                           maxHeight: '24px',


### PR DESCRIPTION
Changed the small image in ObjectBrowserNav to use `/icon` scale in order to not load the full image and load faster.  

Added a preview image in the popup that uses `/mini` image scale to see the image selected.
 

https://user-images.githubusercontent.com/44702393/216933701-3a34d503-cc82-42bd-a67d-7171eba6c0cd.mp4

