### PR TITLE
Fix history diff page not working

### DIFF
--- a/src/customizations/volto/components/manage/Diff/DiffField.jsx
+++ b/src/customizations/volto/components/manage/Diff/DiffField.jsx
@@ -20,6 +20,7 @@ import { DefaultView } from '@plone/volto/components/';
 import { serializeNodes } from '@plone/volto-slate/editor/render';
 
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+import { isObject } from 'addons/volto-searchlib/searchlib';
 
 /**
  * Enhanced diff words utility
@@ -79,7 +80,7 @@ const DiffField = ({
   };
 
   let parts, oneArray, twoArray;
-  if (schema.widget) {
+  if (schema.widget && schema.title !== 'Data sources and providers') {
     switch (schema.widget) {
       case 'richtext':
         parts = diffWords(one?.data, two?.data);
@@ -171,6 +172,18 @@ const DiffField = ({
         parts = diffWords(one, two);
         break;
     }
+  } else if (schema.title == 'Data sources and providers') {
+    if (one?.data?.length > 0 && two.data?.length > 0) {
+      let firstString = one.data.reduce((acc, cur) => {
+        return acc + cur?.title + ', ' + cur?.organisation + '<br/>';
+      }, '');
+      firstString = firstString.substring(0, firstString.length - 2);
+      let secondString = two.data.reduce((acc, cur) => {
+        return acc + cur?.title + ', ' + cur?.organisation + '<br/>';
+      }, '');
+      secondString = secondString.substring(0, secondString.length - 2);
+      parts = diffWords(firstString, secondString);
+    }
   } else if (schema.type === 'object') {
     parts = diffWords(one?.filename || one, two?.filename || two);
   } else if (schema.type === 'array') {
@@ -206,8 +219,7 @@ const DiffField = ({
                         !value.includes('href') &&
                         !value.includes('=')
                       )
-                        return `<span class="deletion">${value}</span>`;
-
+                        return acc + `<span class="deletion">${value}</span>`;
                       if (
                         part.added &&
                         !value.includes('<') &&
@@ -246,7 +258,7 @@ const DiffField = ({
                         !value.includes('href') &&
                         !value.includes('=')
                       )
-                        return `<span class="addition">${value}</span>`;
+                        return acc + `<span class="addition">${value}</span>`;
                       if (
                         part.removed &&
                         !value.includes('<') &&
@@ -289,7 +301,7 @@ const DiffField = ({
                         !value.includes('href') &&
                         !value.includes('=')
                       )
-                        return `<span class="deletion">${value}</span>`;
+                        return acc + `<span class="deletion">${value}</span>`;
 
                       if (
                         part.added &&
@@ -302,7 +314,7 @@ const DiffField = ({
                         !value.includes('href') &&
                         !value.includes('=')
                       )
-                        return `<span class="addition">${value}</span>`;
+                        return acc + `<span class="addition">${value}</span>`;
 
                       return acc + value;
                     }, '');

--- a/src/customizations/volto/components/manage/Diff/DiffField.jsx
+++ b/src/customizations/volto/components/manage/Diff/DiffField.jsx
@@ -20,7 +20,6 @@ import { DefaultView } from '@plone/volto/components/';
 import { serializeNodes } from '@plone/volto-slate/editor/render';
 
 import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
-import { isObject } from 'addons/volto-searchlib/searchlib';
 
 /**
  * Enhanced diff words utility

--- a/src/customizations/volto/components/manage/Diff/DiffField.jsx
+++ b/src/customizations/volto/components/manage/Diff/DiffField.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 // import { diffWords as dWords } from 'diff';
 import { join, map } from 'lodash';
 import PropTypes from 'prop-types';
-import { diffJson } from 'diff';
 import { Grid } from 'semantic-ui-react';
 import ReactDOMServer from 'react-dom/server';
 import { Provider } from 'react-intl-redux';

--- a/src/customizations/volto/components/manage/Diff/DiffField.jsx
+++ b/src/customizations/volto/components/manage/Diff/DiffField.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 // import { diffWords as dWords } from 'diff';
 import { join, map } from 'lodash';
 import PropTypes from 'prop-types';
+import { diffJson } from 'diff';
 import { Grid } from 'semantic-ui-react';
 import ReactDOMServer from 'react-dom/server';
 import { Provider } from 'react-intl-redux';
@@ -54,7 +55,7 @@ const DiffField = ({
     if (!str) return [];
     const splitedArray = [];
     let elementCurent = '';
-    let insideTag = 0;
+    let insideTag = false;
     for (let i = 0; i < str.length; i++)
       if (str[i] === '<') {
         if (elementCurent) splitedArray.push(elementCurent);
@@ -70,6 +71,7 @@ const DiffField = ({
         splitedArray.push(elementCurent);
         elementCurent = '';
       } else elementCurent += str[i];
+    if (elementCurent) splitedArray.push(elementCurent);
     return splitedArray;
   };
 
@@ -137,6 +139,34 @@ const DiffField = ({
         );
         break;
       }
+      case 'temporal': {
+        if (one?.temporal?.length > 0 && two.temporal?.length > 0) {
+          let firstString = one.temporal.reduce((acc, cur) => {
+            return acc + cur?.label + ', ';
+          }, '');
+          firstString = firstString.substring(0, firstString.length - 2);
+          let secondString = two.temporal.reduce((acc, cur) => {
+            return acc + cur?.label + ', ';
+          }, '');
+          secondString = secondString.substring(0, secondString.length - 2);
+          parts = diffWords(firstString, secondString);
+        }
+        break;
+      }
+      case 'geolocation': {
+        if (one?.geolocation?.length > 0 && two.geolocation?.length > 0) {
+          let firstString = one.geolocation.reduce((acc, cur) => {
+            return acc + cur?.label + ', ';
+          }, '');
+          firstString = firstString.substring(0, firstString.length - 2);
+          let secondString = two.geolocation.reduce((acc, cur) => {
+            return acc + cur?.label + ', ';
+          }, '');
+          secondString = secondString.substring(0, secondString.length - 2);
+          parts = diffWords(firstString, secondString);
+        }
+        break;
+      }
       case 'textarea':
       default:
         parts = diffWords(one, two);
@@ -151,6 +181,7 @@ const DiffField = ({
   } else {
     parts = diffWords(one?.title || one, two?.title || two);
   }
+
   return (
     <Grid data-testid="DiffField">
       <Grid.Row>

--- a/src/customizations/volto/components/manage/Diff/DiffField.jsx
+++ b/src/customizations/volto/components/manage/Diff/DiffField.jsx
@@ -171,7 +171,7 @@ const DiffField = ({
         parts = diffWords(one, two);
         break;
     }
-  } else if (schema.title == 'Data sources and providers') {
+  } else if (schema.title === 'Data sources and providers') {
     if (one?.data?.length > 0 && two.data?.length > 0) {
       let firstString = one.data.reduce((acc, cur) => {
         return acc + cur?.title + ', ' + cur?.organisation + '<br/>';

--- a/src/customizations/volto/components/manage/Diff/DiffField.jsx
+++ b/src/customizations/volto/components/manage/Diff/DiffField.jsx
@@ -1,0 +1,310 @@
+/**
+ * Diff field component.
+ * @module components/manage/Diff/DiffField
+ */
+
+import React from 'react';
+// import { diffWords as dWords } from 'diff';
+import { join, map } from 'lodash';
+import PropTypes from 'prop-types';
+import { Grid } from 'semantic-ui-react';
+import ReactDOMServer from 'react-dom/server';
+import { Provider } from 'react-intl-redux';
+import { createBrowserHistory } from 'history';
+import { ConnectedRouter } from 'connected-react-router';
+import { useSelector } from 'react-redux';
+
+import { Api } from '@plone/volto/helpers';
+import configureStore from '@plone/volto/store';
+import { DefaultView } from '@plone/volto/components/';
+import { serializeNodes } from '@plone/volto-slate/editor/render';
+
+import { injectLazyLibs } from '@plone/volto/helpers/Loadable/Loadable';
+
+/**
+ * Enhanced diff words utility
+ * @function diffWords
+ * @param oneStr Field one
+ * @param twoStr Field two
+ */
+
+/**
+ * Diff field component.
+ * @function DiffField
+ * @param {*} one Field one
+ * @param {*} two Field two
+ * @param {Object} schema Field schema
+ * @returns {string} Markup of the component.
+ */
+const DiffField = ({
+  one,
+  two,
+  contentOne,
+  contentTwo,
+  view,
+  schema,
+  diffLib,
+}) => {
+  const language = useSelector((state) => state.intl.locale);
+  const readable_date_format = {
+    dateStyle: 'full',
+    timeStyle: 'short',
+  };
+  const splitWords = (str) => {
+    if (!str) return [];
+    const splitedArray = [];
+    let elementCurent = '';
+    let insideTag = 0;
+    for (let i = 0; i < str.length; i++)
+      if (str[i] === '<') {
+        if (elementCurent) splitedArray.push(elementCurent);
+        elementCurent = '<';
+        insideTag = true;
+      } else if (str[i] === '>') {
+        elementCurent += '>';
+        splitedArray.push(elementCurent);
+        elementCurent = '';
+        insideTag = false;
+      } else if (str[i] === ' ' && insideTag === false) {
+        elementCurent += ' ';
+        splitedArray.push(elementCurent);
+        elementCurent = '';
+      } else elementCurent += str[i];
+    return splitedArray;
+  };
+
+  const diffWords = (oneStr, twoStr) => {
+    return diffLib.diffArrays(splitWords(oneStr), splitWords(twoStr));
+  };
+
+  let parts, oneArray, twoArray;
+  if (schema.widget) {
+    switch (schema.widget) {
+      case 'richtext':
+        parts = diffWords(one?.data, two?.data);
+        break;
+      case 'datetime':
+        parts = diffWords(
+          new Intl.DateTimeFormat(language, readable_date_format)
+            .format(new Date(one))
+            .replace('\u202F', ' '),
+          new Intl.DateTimeFormat(language, readable_date_format)
+            .format(new Date(two))
+            .replace('\u202F', ' '),
+        );
+        break;
+      case 'json': {
+        const api = new Api();
+        const history = createBrowserHistory();
+        const store = configureStore(window.__data, history, api);
+        parts = diffWords(
+          ReactDOMServer.renderToStaticMarkup(
+            <Provider store={store}>
+              <ConnectedRouter history={history}>
+                <DefaultView content={contentOne} />
+              </ConnectedRouter>
+            </Provider>,
+          ),
+          ReactDOMServer.renderToStaticMarkup(
+            <Provider store={store}>
+              <ConnectedRouter history={history}>
+                <DefaultView content={contentTwo} />
+              </ConnectedRouter>
+            </Provider>,
+          ),
+        );
+        break;
+      }
+      case 'slate': {
+        const api = new Api();
+        const history = createBrowserHistory();
+        const store = configureStore(window.__data, history, api);
+        parts = diffWords(
+          ReactDOMServer.renderToStaticMarkup(
+            <Provider store={store}>
+              <ConnectedRouter history={history}>
+                {serializeNodes(one)}
+              </ConnectedRouter>
+            </Provider>,
+          ),
+          ReactDOMServer.renderToStaticMarkup(
+            <Provider store={store}>
+              <ConnectedRouter history={history}>
+                {serializeNodes(two)}
+              </ConnectedRouter>
+            </Provider>,
+          ),
+        );
+        break;
+      }
+      case 'textarea':
+      default:
+        parts = diffWords(one, two);
+        break;
+    }
+  } else if (schema.type === 'object') {
+    parts = diffWords(one?.filename || one, two?.filename || two);
+  } else if (schema.type === 'array') {
+    oneArray = (one || []).map((i) => i?.title || i);
+    twoArray = (two || []).map((j) => j?.title || j);
+    parts = diffWords(oneArray, twoArray);
+  } else {
+    parts = diffWords(one?.title || one, two?.title || two);
+  }
+  return (
+    <Grid data-testid="DiffField">
+      <Grid.Row>
+        <Grid.Column width={12}>{schema.title}</Grid.Column>
+      </Grid.Row>
+
+      {view === 'split' && (
+        <Grid.Row>
+          <Grid.Column width={6} verticalAlign="top">
+            <span
+              dangerouslySetInnerHTML={{
+                __html: join(
+                  map(parts, (part) => {
+                    let combined = (part.value || []).reduce((acc, value) => {
+                      if (
+                        part.removed &&
+                        !value.includes('<') &&
+                        !value.includes('>') &&
+                        !value.includes('>') &&
+                        !value.includes('</') &&
+                        !value.includes('"') &&
+                        !value.includes('src') &&
+                        !value.includes('href') &&
+                        !value.includes('=')
+                      )
+                        return `<span class="deletion">${value}</span>`;
+
+                      if (
+                        part.added &&
+                        !value.includes('<') &&
+                        !value.includes('>') &&
+                        !value.includes('>') &&
+                        !value.includes('</') &&
+                        !value.includes('"') &&
+                        !value.includes('src') &&
+                        !value.includes('href') &&
+                        !value.includes('=')
+                      )
+                        return acc;
+                      return acc + value;
+                    }, '');
+                    return combined;
+                  }),
+                  '',
+                ),
+              }}
+            />
+          </Grid.Column>
+          <Grid.Column width={6} verticalAlign="top">
+            <span
+              dangerouslySetInnerHTML={{
+                __html: join(
+                  map(parts, (part) => {
+                    let combined = (part.value || []).reduce((acc, value) => {
+                      if (
+                        part.added &&
+                        !value.includes('<') &&
+                        !value.includes('>') &&
+                        !value.includes('>') &&
+                        !value.includes('</') &&
+                        !value.includes('"') &&
+                        !value.includes('src') &&
+                        !value.includes('href') &&
+                        !value.includes('=')
+                      )
+                        return `<span class="addition">${value}</span>`;
+                      if (
+                        part.removed &&
+                        !value.includes('<') &&
+                        !value.includes('>') &&
+                        !value.includes('>') &&
+                        !value.includes('</') &&
+                        !value.includes('"') &&
+                        !value.includes('src') &&
+                        !value.includes('href') &&
+                        !value.includes('=')
+                      )
+                        return acc;
+                      return acc + value;
+                    }, '');
+                    return combined;
+                  }),
+                  '',
+                ),
+              }}
+            />
+          </Grid.Column>
+        </Grid.Row>
+      )}
+      {view === 'unified' && (
+        <Grid.Row>
+          <Grid.Column width={16} verticalAlign="top">
+            <span
+              dangerouslySetInnerHTML={{
+                __html: join(
+                  map(parts, (part) => {
+                    let combined = (part.value || []).reduce((acc, value) => {
+                      if (
+                        part.removed &&
+                        !value.includes('<') &&
+                        !value.includes('>') &&
+                        !value.includes('>') &&
+                        !value.includes('</') &&
+                        !value.includes('"') &&
+                        !value.includes('src') &&
+                        !value.includes('href') &&
+                        !value.includes('=')
+                      )
+                        return `<span class="deletion">${value}</span>`;
+
+                      if (
+                        part.added &&
+                        !value.includes('<') &&
+                        !value.includes('>') &&
+                        !value.includes('>') &&
+                        !value.includes('</') &&
+                        !value.includes('"') &&
+                        !value.includes('src') &&
+                        !value.includes('href') &&
+                        !value.includes('=')
+                      )
+                        return `<span class="addition">${value}</span>`;
+
+                      return acc + value;
+                    }, '');
+                    return combined;
+                  }),
+                  '',
+                ),
+              }}
+            />
+          </Grid.Column>
+        </Grid.Row>
+      )}
+    </Grid>
+  );
+};
+
+/**
+ * Property types.
+ * @property {Object} propTypes Property types.
+ * @static
+ */
+DiffField.propTypes = {
+  one: PropTypes.any.isRequired,
+  two: PropTypes.any.isRequired,
+  contentOne: PropTypes.any,
+  contentTwo: PropTypes.any,
+  view: PropTypes.string.isRequired,
+  schema: PropTypes.shape({
+    widget: PropTypes.string,
+    type: PropTypes.string,
+    title: PropTypes.string,
+  }).isRequired,
+};
+
+export default injectLazyLibs('diffLib')(DiffField);

--- a/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
+++ b/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
@@ -10,12 +10,8 @@ const AppExtras = (props) => {
   const active = appExtras
     .map((reg) => {
       const match = matchPath(pathname, reg.match);
-      if (
-        reg.exceptions?.length > 0 &&
-        reg.exceptions.filter((e) => e.test(pathname)).length > 0
-      )
-        return null;
-      return match ? { reg, match } : null;
+      const excluded = matchPath(pathname, reg.exclude);
+      return !excluded && match ? { reg, match } : null;
     })
     .filter((reg) => reg);
 

--- a/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
+++ b/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
@@ -1,0 +1,30 @@
+//this should be deleted when upgraded to a volto version that supports App Extras exceptions
+import React from 'react';
+import { matchPath } from 'react-router';
+import config from '@plone/volto/registry';
+
+const AppExtras = (props) => {
+  const { settings } = config;
+  const { appExtras = [] } = settings;
+  const { pathname } = props;
+  const active = appExtras
+    .map((reg) => {
+      const match = matchPath(pathname, reg.match);
+      if (
+        reg.exceptions?.length > 0 &&
+        reg.exceptions.filter((e) => e.test(pathname)).length > 0
+      )
+        return null;
+      return match ? { reg, match } : null;
+    })
+    .filter((reg) => reg);
+
+  return active.map(({ reg: { component, props: extraProps }, match }, i) => {
+    const Insert = component;
+    return (
+      <Insert key={`appextra-${i}`} match={match} {...props} {...extraProps} />
+    );
+  });
+};
+
+export default AppExtras;

--- a/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
+++ b/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
@@ -12,7 +12,6 @@ const AppExtras = (props) => {
       const excluded = matchPath(pathname, reg.exclude);
       if (excluded) return null;
       const match = matchPath(pathname, reg.match);
-
       return match ? { reg, match } : null;
     })
     .filter((reg) => reg);

--- a/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
+++ b/src/customizations/volto/components/theme/AppExtras/AppExtras.jsx
@@ -9,9 +9,11 @@ const AppExtras = (props) => {
   const { pathname } = props;
   const active = appExtras
     .map((reg) => {
-      const match = matchPath(pathname, reg.match);
       const excluded = matchPath(pathname, reg.exclude);
-      return !excluded && match ? { reg, match } : null;
+      if (excluded) return null;
+      const match = matchPath(pathname, reg.match);
+
+      return match ? { reg, match } : null;
     })
     .filter((reg) => reg);
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -303,7 +303,7 @@ describe('applyConfig', () => {
       { match: '', component: 'MockedDraftBackground' },
       { match: '', component: 'MockedSubsiteClass' },
       { match: '', component: BaseTag },
-      { match: '*', component: 'MockedRemoveSchema' },
+      { match: '*', exclude: '/**/diff', component: 'MockedRemoveSchema' },
     ]);
     expect(config.settings.available_colors).toEqual(eea.colors);
     expect(config.settings.hasLanguageDropdown).toBe(false);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -144,7 +144,7 @@ describe('applyConfig', () => {
       { match: '', component: 'MockedDraftBackground' },
       { match: '', component: 'MockedSubsiteClass' },
       { match: '', component: BaseTag },
-      { match: '*', component: 'MockedRemoveSchema' },
+      { match: '*', exclude: '/**/diff', component: 'MockedRemoveSchema' },
     ]);
     expect(config.settings.available_colors).toEqual(eea.colors);
     expect(config.settings.hasLanguageDropdown).toBe(false);

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,6 +9,7 @@ export default function applyConfig(config) {
     ...(config.settings.appExtras || []),
     {
       match: '*',
+      exceptions: [/.*diff(?:\?.*)?$/],
       component: RemoveSchema,
     },
   ];

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -9,7 +9,7 @@ export default function applyConfig(config) {
     ...(config.settings.appExtras || []),
     {
       match: '*',
-      exceptions: [/.*diff(?:\?.*)?$/],
+      exclude: '/**/diff',
       component: RemoveSchema,
     },
   ];


### PR DESCRIPTION
As we all know the history diff page was not working properly. On a lots of pages, the history diff page was broken like this:
![image](https://github.com/eea/volto-eea-website-theme/assets/50819975/3499f682-4766-4865-bc49-ce9e34c937d3)

The bug was because of the diff algorithm used by Volto, as it was treating the content like strings, which is incorrect because is different to parse an HTML than a basic string.
I have made the following improvements:
1. I have come up with an algorithm that will know how to parse HTML and strings. This is good because when we have a block of text we want to compare the text, but if we have 2 images with different sources, we don't want to compare the source value, but to see the images.
2. I have upgraded the algorithm to show also the metadata values like temporal coverage, etc.

3. I have come up with an exclusion property for App Extras rules