### PR TITLE
change(UniversalLink): add @@download/file only if download prop is true

### DIFF
--- a/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
@@ -29,6 +29,7 @@ const UniversalLink = ({
   const token = useSelector((state) => state.userSession?.token);
 
   let url = href;
+
   if (!href && item) {
     if (!item['@id']) {
       // eslint-disable-next-line no-console
@@ -68,13 +69,8 @@ const UniversalLink = ({
 
   const isExternal = !isInternalURL(url);
 
-  const isDownload = !isExternal && download;
-  if (!isDownload && url) {
-    url = url.replace('/@@download/file', '');
-  }
-  if (isDownload && url) {
-    url = url.includes('/@@download/file') ? url : `${url}/@@download/file`;
-  }
+  const isDownload = !isExternal && url && url.includes('@@download/file');
+
   const isDisplayFile =
     (!isExternal && url.includes('@@display-file')) || false;
   const checkedURL = URLUtils.checkAndNormalizeUrl(url);

--- a/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
+++ b/src/customizations/volto/components/manage/UniversalLink/UniversalLink.jsx
@@ -51,10 +51,10 @@ const UniversalLink = ({
 
       //case: item of type 'File'
       if (
-        !token &&
+        download &&
         config.settings.downloadableObjects.includes(item['@type'])
       ) {
-        url = `${url}/@@download/file`;
+        url = url.includes('/@@download/file') ? url : `${url}/@@download/file`;
       }
 
       if (
@@ -68,10 +68,15 @@ const UniversalLink = ({
 
   const isExternal = !isInternalURL(url);
 
-  const isDownload = (!isExternal && url.includes('@@download')) || download;
+  const isDownload = !isExternal && download;
+  if (!isDownload && url) {
+    url = url.replace('/@@download/file', '');
+  }
+  if (isDownload && url) {
+    url = url.includes('/@@download/file') ? url : `${url}/@@download/file`;
+  }
   const isDisplayFile =
     (!isExternal && url.includes('@@display-file')) || false;
-
   const checkedURL = URLUtils.checkAndNormalizeUrl(url);
 
   // we can receive an item with a linkWithHash property set from ObjectBrowserWidget


### PR DESCRIPTION
- This way we can use dedicated packages such as volto-call-to-action-block which has a schema field named download which passed the prop to UniversalLink and it allows the editor to choose for everyone if the file should download or not