### PR TITLE
(feat+fix): transform empty blocks to slate refs 273976

### DIFF
--- a/src/customizations/volto/components/manage/Blocks/Grid/View.jsx
+++ b/src/customizations/volto/components/manage/Blocks/Grid/View.jsx
@@ -4,7 +4,7 @@ import { RenderBlocks } from '@plone/volto/components';
 import { withBlockExtensions } from '@plone/volto/helpers';
 import config from '@plone/volto/registry';
 
-const convertTeaserToGridIfNecessary = (data) => {
+const convertTeaserToGridIfNecessaryAndTransformEmptyBlocksToSlate = (data) => {
   if (data?.['@type'] === 'teaserGrid')
     return {
       ...data,
@@ -13,11 +13,24 @@ const convertTeaserToGridIfNecessary = (data) => {
       blocks: data?.columns?.reduce((acc, current) => {
         return {
           ...acc,
-          [current?.id]: current,
+          [current?.id]: { current, '@type': current['@type'] || 'slate' },
         };
       }, {}),
     };
-  return data;
+  if (data.blocks)
+    return {
+      ...data,
+      blocks: Object.keys(data.blocks).reduce((acc, current) => {
+        return {
+          ...acc,
+          [current]: {
+            ...data.blocks[current],
+            '@type': data.blocks[current]?.['@type'] || 'slate',
+          },
+        };
+      }, {}),
+    };
+  else return data;
 };
 
 const GridBlockView = (props) => {
@@ -48,7 +61,9 @@ const GridBlockView = (props) => {
           {...props}
           blockWrapperTag={Grid.Column}
           metadata={metadata}
-          content={convertTeaserToGridIfNecessary(data)}
+          content={convertTeaserToGridIfNecessaryAndTransformEmptyBlocksToSlate(
+            data,
+          )}
           location={location}
           blocksConfig={blocksConfig}
           isContainer

--- a/src/customizations/volto/components/manage/Blocks/Grid/readme.md
+++ b/src/customizations/volto/components/manage/Blocks/Grid/readme.md
@@ -1,1 +1,2 @@
 These two customizations ensure backward compatibility with the legacy @kitconcept/volto-blocks-grid. For more details, refer to the ticket here: https://taskman.eionet.europa.eu/issues/265726.
+Also, if there is an empty block, it will convert to slate, so the "Unkown block" message will not appear


### PR DESCRIPTION
https://taskman.eionet.europa.eu/issues/273976?issue_count=3&issue_position=1&next_issue_id=262240

With this change the empty blocks will be transformed to slate, to prevent showing the error message of "Unkown block"

Before:
<img width="998" alt="Captură de ecran din 2024-08-28 la 12 17 10" src="https://github.com/user-attachments/assets/8fcf4f50-45fb-4589-9874-1d848a52270d">

After:
<img width="974" alt="Captură de ecran din 2024-08-28 la 12 16 05" src="https://github.com/user-attachments/assets/58ef9f24-23a9-4adf-8b8d-7452b979347a">

