### PR TITLE
fix(context-navigation): re-rendering that was triggered when typing inside a slate

### DIFF
--- a/src/components/manage/Blocks/ContextNavigation/ContextNavigationEdit.jsx
+++ b/src/components/manage/Blocks/ContextNavigation/ContextNavigationEdit.jsx
@@ -7,6 +7,14 @@ import ContextNavigationView from './ContextNavigationView';
 
 import { useSelector, shallowEqual } from 'react-redux';
 
+function arePropsEqual(oldProps, newProps) {
+  return (
+    newProps.selected === oldProps.selected &&
+    newProps.data === oldProps.data &&
+    newProps.id === oldProps.id
+  );
+}
+
 const ContextNavigationFillEdit = (props) => {
   const contentTypes = useSelector(
     (state) => state.types?.types || [],
@@ -16,6 +24,7 @@ const ContextNavigationFillEdit = (props) => {
     () => contentTypes?.map((type) => [type.id, type.title || type.name]),
     [contentTypes],
   );
+
   const schema = React.useMemo(
     () => EditSchema({ availableTypes }),
     [availableTypes],
@@ -46,4 +55,4 @@ const ContextNavigationFillEdit = (props) => {
   );
 };
 
-export default ContextNavigationFillEdit;
+export default React.memo(ContextNavigationFillEdit, arePropsEqual);

--- a/src/components/manage/Blocks/ContextNavigation/ContextNavigationView.jsx
+++ b/src/components/manage/Blocks/ContextNavigation/ContextNavigationView.jsx
@@ -2,27 +2,27 @@ import React from 'react';
 import { flattenToAppURL, withBlockExtensions } from '@plone/volto/helpers';
 import DefaultTemplate from './variations/Default';
 
-const ContextNavigationView = React.memo(
-  (props = {}) => {
-    const { variation, data = {} } = props;
-    const navProps = React.useMemo(() => {
-      const props = { ...data };
-      const root_path = data?.root_node?.[0]?.['@id'];
-      if (root_path) props['root_path'] = flattenToAppURL(root_path);
-      return props;
-    }, [data]);
+function arePropsEqual(prevProps, nextProps) {
+  // check if component should be re-rendered
+  return (
+    prevProps.mode === nextProps.mode &&
+    prevProps.id === nextProps.id &&
+    prevProps.path === nextProps.path &&
+    JSON.stringify(prevProps.data) === JSON.stringify(nextProps.data)
+  );
+}
 
-    const Renderer = variation?.view ?? DefaultTemplate;
-    return <Renderer params={navProps} mode={props.mode} />;
-  },
-  (prevProps, nextProps) => {
-    // check if props have changed for memo
-    return (
-      prevProps.mode === nextProps.mode &&
-      prevProps.variation === nextProps.variation &&
-      JSON.stringify(prevProps.data) === JSON.stringify(nextProps.data)
-    );
-  },
-);
+const ContextNavigationView = React.memo((props = {}) => {
+  const { variation, data = {} } = props;
+  const navProps = React.useMemo(() => {
+    const props = { ...data };
+    const root_path = data?.root_node?.[0]?.['@id'];
+    if (root_path) props['root_path'] = flattenToAppURL(root_path);
+    return props;
+  }, [data]);
+
+  const Renderer = variation?.view ?? DefaultTemplate;
+  return <Renderer params={navProps} mode={props.mode} />;
+}, arePropsEqual);
 
 export default withBlockExtensions(ContextNavigationView);


### PR DESCRIPTION
- This way we avoid unnecessary re-renders that previously also made a fetch call to @contextNavigation endpoint