### PR TITLE
Fix Slate backspace handling for bold links Refs #304369

### DIFF
--- a/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js
+++ b/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js
@@ -1,0 +1,214 @@
+import ReactDOM from 'react-dom';
+import cloneDeep from 'lodash/cloneDeep';
+import { serializeNodesToText } from '@plone/volto-slate/editor/render';
+import { Editor } from 'slate';
+import {
+  getPreviousVoltoBlock,
+  getNextVoltoBlock,
+  mergeSlateWithBlockForward,
+  mergeSlateWithBlockBackward,
+} from '@plone/volto-slate/utils/volto-blocks';
+import {
+  isCursorAtBlockStart,
+  isCursorAtBlockEnd,
+} from '@plone/volto-slate/utils/selection';
+import { makeEditor } from '@plone/volto-slate/utils/editor';
+import {
+  changeBlock,
+  deleteBlock,
+  getBlocksFieldname,
+  getBlocksLayoutFieldname,
+} from '@plone/volto/helpers/Blocks/Blocks';
+
+// Full shadow copy of Volto 18's joinBlocks keyboard handler.
+// Actual customization: joinWithPreviousBlock restores the Volto 17 guard that
+// only allows Backspace block merges when the previous block is also Slate.
+
+/**
+ * Joins the current block (which has an active Slate Editor)
+ * with the previous block, to make a single block.
+ *
+ * @param {Editor} editor
+ * @param {KeyboardEvent} event
+ */
+export function joinWithPreviousBlock({ editor, event }, intl) {
+  if (!isCursorAtBlockStart(editor)) return;
+
+  const blockProps = editor.getBlockProps();
+  const {
+    block,
+    index,
+    saveSlateBlockSelection,
+    onSelectBlock,
+    data,
+    properties,
+    onChangeField,
+  } = blockProps;
+
+  const blocksFieldname = getBlocksFieldname(properties);
+  const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+
+  const prev = getPreviousVoltoBlock(index, properties);
+  if (!prev) return;
+  const [otherBlock = {}, otherBlockId] = prev;
+
+  // EEA customization: restore Volto 17 guard. Volto 18 tries to merge with
+  // any previous block, but only Slate blocks have the value needed below.
+  if (data?.required || otherBlock?.required || otherBlock['@type'] !== 'slate')
+    return;
+
+  event.stopPropagation();
+  event.preventDefault();
+
+  // If the Editor contains no characters TODO: clarify if this special case
+  // really needs to be handled or not. In `joinWithNextBlock` it is not
+  // handled.
+  const text = Editor.string(editor, []);
+  if (!text) {
+    const cursor = getBlockEndAsRange(otherBlock);
+    const newFormData = deleteBlock(properties, block, intl);
+
+    ReactDOM.unstable_batchedUpdates(() => {
+      saveSlateBlockSelection(otherBlockId, cursor);
+
+      onChangeField(blocksFieldname, newFormData[blocksFieldname]);
+      onChangeField(blocksLayoutFieldname, newFormData[blocksLayoutFieldname]);
+
+      onSelectBlock(otherBlockId);
+    });
+
+    return true;
+  }
+
+  // Else the editor contains characters, so we merge the current block's
+  // `editor` with the block before, `otherBlock`.
+  const cursor = mergeSlateWithBlockBackward(editor, otherBlock, event);
+
+  // Get the merged content from the editor
+  const merged = JSON.parse(JSON.stringify(editor.children));
+
+  // // TODO: don't remove undo history, etc Should probably save both undo
+  // // histories, so that the blocks are split, the undos can be restored??
+
+  // const cursor = getBlockEndAsRange(otherBlock);
+
+  const formData = changeBlock(properties, otherBlockId, {
+    '@type': 'slate', // TODO: use a constant specified in src/constants.js instead of 'slate'
+    value: merged,
+    plaintext: serializeNodesToText(merged || []),
+  });
+  const newFormData = deleteBlock(formData, block, intl);
+  ReactDOM.unstable_batchedUpdates(() => {
+    saveSlateBlockSelection(otherBlockId, cursor);
+    onChangeField(blocksFieldname, newFormData[blocksFieldname]);
+    onChangeField(blocksLayoutFieldname, newFormData[blocksLayoutFieldname]);
+    onSelectBlock(otherBlockId);
+  });
+
+  return true;
+}
+
+/**
+ * Joins the current block (which has the cursor) with the next block to make a
+ * single block.
+ * @param {Editor} editor
+ * @param {KeyboardEvent} event
+ */
+export function joinWithNextBlock({ editor, event }, intl) {
+  if (!isCursorAtBlockEnd(editor)) return;
+
+  const blockProps = editor.getBlockProps();
+  const {
+    block,
+    index,
+    // saveSlateBlockSelection,
+    onSelectBlock,
+    data,
+  } = blockProps;
+
+  const { properties, onChangeField } = editor.getBlockProps();
+  const [otherBlock = {}, otherBlockId] = getNextVoltoBlock(index, properties);
+
+  if (!otherBlockId) {
+    return false;
+  }
+
+  // Don't join with required blocks
+  if (data?.required || otherBlock?.required || otherBlock['@type'] !== 'slate')
+    return;
+
+  event.stopPropagation();
+  event.preventDefault();
+
+  const blocksFieldname = getBlocksFieldname(properties);
+  const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+
+  // If next block is not a slate text block, do nothing
+  if (otherBlock['@type'] !== 'slate') {
+    return;
+  }
+
+  const nextValue = otherBlock?.value;
+  const nextPlaintext =
+    otherBlock?.plaintext ?? serializeNodesToText(nextValue || []);
+  // Treat the next block as empty if both its structured value and plaintext representation
+  // indicate no content. In that case we can delete it instead of attempting a merge.
+  const isEmptySlateBlock =
+    !Array.isArray(nextValue) ||
+    nextValue.length === 0 ||
+    !nextPlaintext ||
+    nextPlaintext.trim().length === 0;
+
+  if (isEmptySlateBlock) {
+    const newFormData = deleteBlock(properties, otherBlockId, intl);
+    ReactDOM.unstable_batchedUpdates(() => {
+      onChangeField(blocksFieldname, newFormData[blocksFieldname]);
+      onChangeField(blocksLayoutFieldname, newFormData[blocksLayoutFieldname]);
+      onSelectBlock(block);
+    });
+    return true;
+  }
+  // Merge next text block into current one and delete the next block
+  mergeSlateWithBlockForward(editor, otherBlock);
+
+  const combined = JSON.parse(JSON.stringify(editor.children));
+
+  const formData = changeBlock(properties, block, {
+    '@type': 'slate',
+    value: combined,
+    plaintext: serializeNodesToText(combined || []),
+  });
+
+  const newFormData = deleteBlock(formData, otherBlockId, intl);
+
+  ReactDOM.unstable_batchedUpdates(() => {
+    onChangeField(blocksFieldname, newFormData[blocksFieldname]);
+    onChangeField(blocksLayoutFieldname, newFormData[blocksLayoutFieldname]);
+    onSelectBlock(block);
+  });
+  return true;
+}
+
+/**
+ * @param {object} block The Volto object representing the configuration and
+ * contents of a Volto Block of type Slate Text.
+ * @returns {Range} The collapsed Slate Range that represents the last position
+ * the text cursor can take inside the given block.
+ */
+function getBlockEndAsRange(block) {
+  const { value } = block;
+  const location = [value.length - 1]; // adress of root node
+  const editor = { children: value };
+  const newEditor = makeEditor();
+  newEditor.children = cloneDeep(editor.children);
+  const path = Editor.last(newEditor, location)[1]; // last Node in the block
+  // The last Text node (leaf node) entry inside the path computed just above.
+  const [leaf, leafpath] = Editor.leaf(newEditor, path);
+  // The offset of the Points in the collapsed Range computed below:
+  const offset = (leaf.text || '').length;
+
+  return {
+    anchor: { path: leafpath, offset },
+    focus: { path: leafpath, offset },
+  };
+}

--- a/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js
+++ b/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js
@@ -20,7 +20,6 @@ import {
   getBlocksLayoutFieldname,
 } from '@plone/volto/helpers/Blocks/Blocks';
 
-// Full shadow copy of Volto 18's joinBlocks keyboard handler.
 // Actual customization: joinWithPreviousBlock restores the Volto 17 guard that
 // only allows Backspace block merges when the previous block is also Slate.
 

--- a/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js.diff
+++ b/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js.diff
@@ -1,18 +1,17 @@
 --- node_modules/@plone/volto-slate/src/blocks/Text/keyboard/joinBlocks.js	2026-06-05 17:35:10.949302482 +0300
-+++ src/addons/volto-eea-website-theme/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js	2026-06-11 16:40:47.809380106 +0300
-@@ -19,6 +19,11 @@
++++ src/addons/volto-eea-website-theme/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js	2026-06-11 17:35:57.282584459 +0300
+@@ -19,6 +19,10 @@
    getBlocksFieldname,
    getBlocksLayoutFieldname,
  } from '@plone/volto/helpers/Blocks/Blocks';
 +
-+// Full shadow copy of Volto 18's joinBlocks keyboard handler.
 +// Actual customization: joinWithPreviousBlock restores the Volto 17 guard that
 +// only allows Backspace block merges when the previous block is also Slate.
 +
  /**
   * Joins the current block (which has an active Slate Editor)
   * with the previous block, to make a single block.
-@@ -47,8 +52,10 @@
+@@ -47,8 +51,10 @@
    if (!prev) return;
    const [otherBlock = {}, otherBlockId] = prev;
  

--- a/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js.diff
+++ b/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js.diff
@@ -1,0 +1,27 @@
+--- node_modules/@plone/volto-slate/src/blocks/Text/keyboard/joinBlocks.js	2026-06-05 17:35:10.949302482 +0300
++++ src/addons/volto-eea-website-theme/src/customizations/@plone/volto-slate/blocks/Text/keyboard/joinBlocks.js	2026-06-11 16:40:47.809380106 +0300
+@@ -19,6 +19,11 @@
+   getBlocksFieldname,
+   getBlocksLayoutFieldname,
+ } from '@plone/volto/helpers/Blocks/Blocks';
++
++// Full shadow copy of Volto 18's joinBlocks keyboard handler.
++// Actual customization: joinWithPreviousBlock restores the Volto 17 guard that
++// only allows Backspace block merges when the previous block is also Slate.
++
+ /**
+  * Joins the current block (which has an active Slate Editor)
+  * with the previous block, to make a single block.
+@@ -47,8 +52,10 @@
+   if (!prev) return;
+   const [otherBlock = {}, otherBlockId] = prev;
+ 
+-  // Don't join with required blocks
+-  if (data?.required || otherBlock?.required) return;
++  // EEA customization: restore Volto 17 guard. Volto 18 tries to merge with
++  // any previous block, but only Slate blocks have the value needed below.
++  if (data?.required || otherBlock?.required || otherBlock['@type'] !== 'slate')
++    return;
+ 
+   event.stopPropagation();
+   event.preventDefault();

--- a/src/customizations/@plone/volto-slate/editor/render.jsx
+++ b/src/customizations/@plone/volto-slate/editor/render.jsx
@@ -21,12 +21,33 @@ import '@plone/volto-slate/editor/less/slate.less';
 
 const OMITTED = ['editor', 'path'];
 
+// EEA customization: inline markup renderers in Volto 18 do not pass Slate
+// attributes, so empty formatted elements cannot be resolved back to DOM nodes.
+const inlineMarkupElements = {
+  em: 'em',
+  i: 'i',
+  b: 'b',
+  strong: 'strong',
+  u: 'u',
+  s: 'del',
+  del: 'del',
+  sub: 'sub',
+  sup: 'sup',
+  code: 'code',
+};
+
 // TODO: read, see if relevant
 // https://reactjs.org/docs/higher-order-components.html#dont-use-hocs-inside-the-render-method
 export const Element = ({ element, attributes = {}, extras, ...rest }) => {
   const { slate } = config.settings;
   const { elements } = slate;
-  const El = elements[element.type] || elements['default'];
+  // EEA customization: for inline markup elements, bypass Volto's renderers
+  // that drop Slate attributes and render the native tag with attributes.
+  const inlineMarkupTag = inlineMarkupElements[element.type];
+  const El = inlineMarkupTag
+    ? ({ attributes, children }) =>
+        React.createElement(inlineMarkupTag, attributes, children)
+    : elements[element.type] || elements['default'];
 
   // CUSTOMIZATION Code fix
   const attrs = Object.keys(attributes || {}).reduce(

--- a/src/customizations/@plone/volto-slate/editor/render.jsx
+++ b/src/customizations/@plone/volto-slate/editor/render.jsx
@@ -11,7 +11,7 @@ import isEqual from 'lodash/isEqual';
 import omit from 'lodash/omit';
 import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
 import Toast from '@plone/volto/components/manage/Toast/Toast';
-import { messages } from '@plone/volto/helpers//MessageLabels/MessageLabels';
+import { messages } from '@plone/volto/helpers/MessageLabels/MessageLabels';
 import { addAppURL } from '@plone/volto/helpers/Url/Url';
 import useClipboard from '@plone/volto/hooks/clipboard/useClipboard';
 import config from '@plone/volto/registry';

--- a/src/customizations/@plone/volto-slate/editor/render.jsx.diff
+++ b/src/customizations/@plone/volto-slate/editor/render.jsx.diff
@@ -1,22 +1,8 @@
---- node_modules/@plone/volto-slate/src/editor/render.jsx	2026-06-05 17:35:11.085998662 +0300
-+++ src/addons/volto-eea-website-theme/src/customizations/@plone/volto-slate/editor/render.jsx	2026-06-11 16:41:00.288292262 +0300
-@@ -7,32 +7,64 @@
- import { Node, Text } from 'slate';
- import cx from 'classnames';
- import isEmpty from 'lodash/isEmpty';
-+import isEqual from 'lodash/isEqual';
- import omit from 'lodash/omit';
- import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
- import Toast from '@plone/volto/components/manage/Toast/Toast';
--import { messages } from '@plone/volto/helpers/MessageLabels/MessageLabels';
-+import { messages } from '@plone/volto/helpers//MessageLabels/MessageLabels';
- import { addAppURL } from '@plone/volto/helpers/Url/Url';
- import useClipboard from '@plone/volto/hooks/clipboard/useClipboard';
- import config from '@plone/volto/registry';
- import linkSVG from '@plone/volto/icons/link.svg';
- 
--import './less/slate.less';
-+import '@plone/volto-slate/editor/less/slate.less';
+diff --git a/src/customizations/@plone/volto-slate/editor/render.jsx b/src/customizations/@plone/volto-slate/editor/render.jsx
+index d3d7e0b..755a52e 100644
+--- a/src/customizations/@plone/volto-slate/editor/render.jsx
++++ b/src/customizations/@plone/volto-slate/editor/render.jsx
+@@ -21,12 +21,33 @@ import '@plone/volto-slate/editor/less/slate.less';
  
  const OMITTED = ['editor', 'path'];
  
@@ -41,8 +27,6 @@
    const { slate } = config.settings;
    const { elements } = slate;
 -  const El = elements[element.type] || elements['default'];
--
--  const attrs = Object.assign(
 +  // EEA customization: for inline markup elements, bypass Volto's renderers
 +  // that drop Slate attributes and render the native tag with attributes.
 +  const inlineMarkupTag = inlineMarkupElements[element.type];
@@ -50,96 +34,6 @@
 +    ? ({ attributes, children }) =>
 +        React.createElement(inlineMarkupTag, attributes, children)
 +    : elements[element.type] || elements['default'];
-+
-+  // CUSTOMIZATION Code fix
-+  const attrs = Object.keys(attributes || {}).reduce(
-+    (acc, k) => {
-+      if (!isEmpty(attributes[k])) {
-+        if (k === 'className') {
-+          acc.className = cx(attributes.className, acc.className);
-+        } else {
-+          acc[k] = attributes[k];
-+        }
-+      }
-+      return acc;
-+    },
-     element.styleName ? { className: element.styleName } : {},
--    ...Object.keys(attributes || {}).map((k) =>
--      !isEmpty(attributes[k]) ? { [k]: attributes[k] } : {},
--    ),
-   );
-+  // END CUSTOMIZATION
-+
-   attrs.ref = attributes?.ref; // never remove the ref
  
-   return (
-@@ -73,10 +105,11 @@
-     typeof children === 'string' ? (
-       children.split('\n').map((t, i) => {
-         // Softbreak support. Should do a plugin?
-+        const hasSoftBreak =
-+          children.indexOf('\n') > -1 && children.split('\n').length - 1 > i;
-         return (
-           <React.Fragment key={`${i}`}>
--            {children.indexOf('\n') > -1 &&
--            children.split('\n').length - 1 > i ? (
-+            {hasSoftBreak ? (
-               <>
-                 {klass ? <span className={klass}>{t}</span> : t}
-                 <br />
-@@ -107,7 +140,20 @@
-   const editor = { children: nodes || [] };
- 
-   const _serializeNodes = (nodes) => {
--    return (nodes || []).map(([node, path], i) => {
-+    return (nodes || []).map(([node, path]) => {
-+      let _serialized;
-+      const isTextNode = Text.isText(node);
-+      try {
-+        if (!isTextNode) {
-+          _serialized = _serializeNodes(
-+            Array.from(Node.children(editor, path)),
-+          );
-+        }
-+      } catch {
-+        // eslint-disable-next-line no-console
-+        console.error('Error in serializing nodes', editor, path);
-+      }
-+
-       return Text.isText(node) ? (
-         <Leaf path={path} leaf={node} text={node} mode="view" key={path}>
-           {node.text}
-@@ -119,10 +165,16 @@
-           mode="view"
-           key={path}
-           data-slate-data={node.data ? serializeData(node) : null}
--          attributes={getAttributes ? getAttributes(node, path) : null}
-+          attributes={
-+            isEqual(path, [0])
-+              ? getAttributes
-+                ? getAttributes(node, path)
-+                : null
-+              : null
-+          }
-           extras={extras}
-         >
--          {_serializeNodes(Array.from(Node.children(editor, path)))}
-+          {_serialized}
-         </Element>
-       );
-     });
-@@ -196,10 +248,10 @@
-             <style>
-               {/* Prettify the unstyled flash of the link icon on development */}
-               {`
--              a.anchor svg {
--                height: var(--anchor-svg-height, 24px);
--              }
--              `}
-+                a.anchor svg {
-+                  height: var(--anchor-svg-height, 24px);
-+                }
-+                `}
-             </style>
-             <svg
-               {...linkSVG.attributes}
+   // CUSTOMIZATION Code fix
+   const attrs = Object.keys(attributes || {}).reduce(

--- a/src/customizations/@plone/volto-slate/editor/render.jsx.diff
+++ b/src/customizations/@plone/volto-slate/editor/render.jsx.diff
@@ -1,0 +1,145 @@
+--- node_modules/@plone/volto-slate/src/editor/render.jsx	2026-06-05 17:35:11.085998662 +0300
++++ src/addons/volto-eea-website-theme/src/customizations/@plone/volto-slate/editor/render.jsx	2026-06-11 16:41:00.288292262 +0300
+@@ -7,32 +7,64 @@
+ import { Node, Text } from 'slate';
+ import cx from 'classnames';
+ import isEmpty from 'lodash/isEmpty';
++import isEqual from 'lodash/isEqual';
+ import omit from 'lodash/omit';
+ import UniversalLink from '@plone/volto/components/manage/UniversalLink/UniversalLink';
+ import Toast from '@plone/volto/components/manage/Toast/Toast';
+-import { messages } from '@plone/volto/helpers/MessageLabels/MessageLabels';
++import { messages } from '@plone/volto/helpers//MessageLabels/MessageLabels';
+ import { addAppURL } from '@plone/volto/helpers/Url/Url';
+ import useClipboard from '@plone/volto/hooks/clipboard/useClipboard';
+ import config from '@plone/volto/registry';
+ import linkSVG from '@plone/volto/icons/link.svg';
+ 
+-import './less/slate.less';
++import '@plone/volto-slate/editor/less/slate.less';
+ 
+ const OMITTED = ['editor', 'path'];
+ 
++// EEA customization: inline markup renderers in Volto 18 do not pass Slate
++// attributes, so empty formatted elements cannot be resolved back to DOM nodes.
++const inlineMarkupElements = {
++  em: 'em',
++  i: 'i',
++  b: 'b',
++  strong: 'strong',
++  u: 'u',
++  s: 'del',
++  del: 'del',
++  sub: 'sub',
++  sup: 'sup',
++  code: 'code',
++};
++
+ // TODO: read, see if relevant
+ // https://reactjs.org/docs/higher-order-components.html#dont-use-hocs-inside-the-render-method
+ export const Element = ({ element, attributes = {}, extras, ...rest }) => {
+   const { slate } = config.settings;
+   const { elements } = slate;
+-  const El = elements[element.type] || elements['default'];
+-
+-  const attrs = Object.assign(
++  // EEA customization: for inline markup elements, bypass Volto's renderers
++  // that drop Slate attributes and render the native tag with attributes.
++  const inlineMarkupTag = inlineMarkupElements[element.type];
++  const El = inlineMarkupTag
++    ? ({ attributes, children }) =>
++        React.createElement(inlineMarkupTag, attributes, children)
++    : elements[element.type] || elements['default'];
++
++  // CUSTOMIZATION Code fix
++  const attrs = Object.keys(attributes || {}).reduce(
++    (acc, k) => {
++      if (!isEmpty(attributes[k])) {
++        if (k === 'className') {
++          acc.className = cx(attributes.className, acc.className);
++        } else {
++          acc[k] = attributes[k];
++        }
++      }
++      return acc;
++    },
+     element.styleName ? { className: element.styleName } : {},
+-    ...Object.keys(attributes || {}).map((k) =>
+-      !isEmpty(attributes[k]) ? { [k]: attributes[k] } : {},
+-    ),
+   );
++  // END CUSTOMIZATION
++
+   attrs.ref = attributes?.ref; // never remove the ref
+ 
+   return (
+@@ -73,10 +105,11 @@
+     typeof children === 'string' ? (
+       children.split('\n').map((t, i) => {
+         // Softbreak support. Should do a plugin?
++        const hasSoftBreak =
++          children.indexOf('\n') > -1 && children.split('\n').length - 1 > i;
+         return (
+           <React.Fragment key={`${i}`}>
+-            {children.indexOf('\n') > -1 &&
+-            children.split('\n').length - 1 > i ? (
++            {hasSoftBreak ? (
+               <>
+                 {klass ? <span className={klass}>{t}</span> : t}
+                 <br />
+@@ -107,7 +140,20 @@
+   const editor = { children: nodes || [] };
+ 
+   const _serializeNodes = (nodes) => {
+-    return (nodes || []).map(([node, path], i) => {
++    return (nodes || []).map(([node, path]) => {
++      let _serialized;
++      const isTextNode = Text.isText(node);
++      try {
++        if (!isTextNode) {
++          _serialized = _serializeNodes(
++            Array.from(Node.children(editor, path)),
++          );
++        }
++      } catch {
++        // eslint-disable-next-line no-console
++        console.error('Error in serializing nodes', editor, path);
++      }
++
+       return Text.isText(node) ? (
+         <Leaf path={path} leaf={node} text={node} mode="view" key={path}>
+           {node.text}
+@@ -119,10 +165,16 @@
+           mode="view"
+           key={path}
+           data-slate-data={node.data ? serializeData(node) : null}
+-          attributes={getAttributes ? getAttributes(node, path) : null}
++          attributes={
++            isEqual(path, [0])
++              ? getAttributes
++                ? getAttributes(node, path)
++                : null
++              : null
++          }
+           extras={extras}
+         >
+-          {_serializeNodes(Array.from(Node.children(editor, path)))}
++          {_serialized}
+         </Element>
+       );
+     });
+@@ -196,10 +248,10 @@
+             <style>
+               {/* Prettify the unstyled flash of the link icon on development */}
+               {`
+-              a.anchor svg {
+-                height: var(--anchor-svg-height, 24px);
+-              }
+-              `}
++                a.anchor svg {
++                  height: var(--anchor-svg-height, 24px);
++                }
++                `}
+             </style>
+             <svg
+               {...linkSVG.attributes}

--- a/src/customizations/@plone/volto-slate/utils/selection.js
+++ b/src/customizations/@plone/volto-slate/utils/selection.js
@@ -1,0 +1,244 @@
+import castArray from 'lodash/castArray';
+import cloneDeep from 'lodash/cloneDeep';
+import { Editor, Transforms, Range, Node } from 'slate';
+import { ReactEditor } from 'slate-react';
+import { isCursorInList } from '@plone/volto-slate/utils/lists';
+import { makeEditor } from '@plone/volto-slate/utils/editor';
+import { LI } from '@plone/volto-slate/constants';
+import config from '@plone/volto/registry';
+
+// Full shadow copy of Volto 18's selection utility.
+// Actual customization: isCursorAtBlockStart restores the stricter Volto 17
+// check so Backspace inside nested inline text is not treated as block start.
+
+/**
+ * Get the nodes with a type included in `types` in the selection (from root to leaf).
+ *
+ * @param {} editor
+ * @param {} types
+ * @param {} options
+ */
+export function getSelectionNodesByType(editor, types, options = {}) {
+  types = castArray(types);
+
+  return Editor.nodes(editor, {
+    match: (n) => {
+      return types.includes(n.type);
+    },
+    ...options,
+  });
+}
+
+/**
+ * Is there a node with a type included in `types` in the selection (from root to leaf).
+ */
+export function isNodeInSelection(editor, types, options = {}) {
+  const [match] = getSelectionNodesByType(editor, types, options);
+  return !!match;
+}
+
+/**
+ * getSelectionNodesArrayByType.
+ *
+ * @param {} editor
+ * @param {} types
+ * @param {} options
+ */
+export function getSelectionNodesArrayByType(editor, types, options = {}) {
+  return Array.from(getSelectionNodesByType(editor, types, options));
+}
+
+/**
+ * getMaxRange.
+ *
+ * @param {} editor
+ *
+ * TODO: is [0] ok as a path?
+ */
+export function getMaxRange(editor) {
+  const maxRange = {
+    anchor: Editor.start(editor, [0]),
+    focus: Editor.end(editor, [0]),
+  };
+  return maxRange;
+}
+
+/**
+ * selectAll.
+ *
+ * @param {} editor
+ */
+export function selectAll(editor) {
+  Transforms.select(editor, getMaxRange(editor));
+}
+
+// In the isCursorAtBlockStart/End functions maybe use a part of these pieces of code:
+// Range.isCollapsed(editor.selection) &&
+// Point.equals(editor.selection.anchor, Editor.start(editor, []))
+
+/**
+ * isCursorAtBlockStart.
+ *
+ * @param {} editor
+ */
+export function isCursorAtBlockStart(editor) {
+  // It does not work properly with lists
+
+  if (editor.selection && Range.isCollapsed(editor.selection)) {
+    const { anchor } = editor.selection;
+    // EEA customization: restore Volto 17 behavior. Volto 18 only checks
+    // anchor.offset === 0, which also matches the start of nested inline text.
+    return anchor.offset > 0
+      ? false
+      : anchor.path.reduce((acc, x) => acc + x, 0) === 0;
+    // anchor.path.length === 2 &&
+  }
+  return false;
+}
+
+/**
+ * isCursorAtBlockEnd.
+ *
+ * @param {} editor
+ */
+export function isCursorAtBlockEnd(editor) {
+  // fixSelection(editor);
+
+  // if the selection is collapsed
+  if (editor.selection && Range.isCollapsed(editor.selection)) {
+    const anchor = editor.selection?.anchor || {};
+
+    // the last block node in the editor
+    const [node] = Node.last(editor, []);
+
+    if (
+      // if the node with the selection is the last block node
+      Node.get(editor, anchor.path) === node &&
+      // if the collapsed selection is at the end of the last block node
+      anchor.offset === node.text.length
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+const defaultListItemValue = () => {
+  const { slate } = config.settings;
+  const dv = slate.defaultValue();
+  dv[0].type = LI;
+  return dv;
+};
+
+/**
+ * getFragmentFromStartOfSelectionToEndOfEditor.
+ *
+ * @param {} editor
+ */
+export function getFragmentFromStartOfSelectionToEndOfEditor(
+  editor,
+  initialSelection,
+) {
+  if (typeof initialSelection === 'undefined') {
+    initialSelection = editor.selection;
+  }
+
+  const { slate } = config.settings;
+  const range = Editor.range(
+    editor,
+    Range.isBackward(initialSelection)
+      ? initialSelection.focus
+      : initialSelection.anchor,
+    Editor.end(editor, []),
+  );
+
+  // this is the case when the fragment is empty, and we must return
+  // empty fragment but without formatting
+  if (Range.isCollapsed(range)) {
+    if (isCursorInList(editor)) {
+      return defaultListItemValue();
+    } else {
+      return slate.defaultValue();
+    }
+  }
+
+  // immer doesn't like editor.savedSelection
+  const newEditor = makeEditor();
+  newEditor.children = cloneDeep(editor.children);
+  return Editor.fragment(newEditor, range);
+}
+
+/**
+ * getFragmentFromBeginningOfEditorToStartOfSelection.
+ *
+ * @param {} editor
+ */
+export function getFragmentFromBeginningOfEditorToStartOfSelection(
+  editor,
+  initialSelection,
+) {
+  if (typeof initialSelection === 'undefined') {
+    initialSelection = editor.selection;
+  }
+
+  // immer doesn't like editor.savedSelection
+  // TODO: there's a bug here related to splitting lists
+  const newEditor = makeEditor();
+  newEditor.children = cloneDeep(editor.children);
+
+  return Editor.fragment(
+    newEditor,
+    Editor.range(
+      newEditor,
+      [],
+      Range.isBackward(initialSelection)
+        ? initialSelection.focus
+        : initialSelection.anchor,
+    ),
+  );
+}
+
+/**
+ * @returns {boolean} true if editor contains a range selection (active
+ * selection or at least a saved selection)
+ * @param {Editor} editor
+ */
+export function hasRangeSelection(editor, useSavedSelection = true) {
+  const { selection } = editor;
+  const savedSelection = editor.getSavedSelection();
+
+  const range = ReactEditor.isFocused(editor)
+    ? selection || (useSavedSelection ? savedSelection : null)
+    : savedSelection;
+
+  if (!range) {
+    // console.log('no range', editor);
+    return;
+  }
+
+  const res = Range.isExpanded(range);
+  // console.log('call hasRange', res);
+  return res;
+}
+
+export function parseDefaultSelection(editor, defaultSelection) {
+  if (defaultSelection) {
+    if (defaultSelection === 'start') {
+      const [, path] = Node.first(editor, []);
+      const newSel = {
+        anchor: { path, offset: 0 },
+        focus: { path, offset: 0 },
+      };
+      return newSel;
+    }
+    if (defaultSelection === 'end') {
+      const [leaf, path] = Node.last(editor, []);
+      const newSel = {
+        anchor: { path, offset: (leaf.text || '').length },
+        focus: { path, offset: (leaf.text || '').length },
+      };
+      return newSel;
+    }
+    return defaultSelection;
+  }
+}

--- a/src/customizations/@plone/volto-slate/utils/selection.js.diff
+++ b/src/customizations/@plone/volto-slate/utils/selection.js.diff
@@ -1,0 +1,28 @@
+--- node_modules/@plone/volto-slate/src/utils/selection.js	2026-06-05 17:35:11.013853456 +0300
++++ src/addons/volto-eea-website-theme/src/customizations/@plone/volto-slate/utils/selection.js	2026-06-11 16:40:26.970972164 +0300
+@@ -7,6 +7,10 @@
+ import { LI } from '@plone/volto-slate/constants';
+ import config from '@plone/volto/registry';
+ 
++// Full shadow copy of Volto 18's selection utility.
++// Actual customization: isCursorAtBlockStart restores the stricter Volto 17
++// check so Backspace inside nested inline text is not treated as block start.
++
+ /**
+  * Get the nodes with a type included in `types` in the selection (from root to leaf).
+  *
+@@ -82,8 +86,12 @@
+ 
+   if (editor.selection && Range.isCollapsed(editor.selection)) {
+     const { anchor } = editor.selection;
+-    // Check if cursor is at offset 0 of any leaf node (not just the first one)
+-    return anchor.offset === 0;
++    // EEA customization: restore Volto 17 behavior. Volto 18 only checks
++    // anchor.offset === 0, which also matches the start of nested inline text.
++    return anchor.offset > 0
++      ? false
++      : anchor.path.reduce((acc, x) => acc + x, 0) === 0;
++    // anchor.path.length === 2 &&
+   }
+   return false;
+ }

--- a/src/customizations/@plone/volto-slate/utils/volto-blocks.js
+++ b/src/customizations/@plone/volto-slate/utils/volto-blocks.js
@@ -1,0 +1,343 @@
+import ReactDOM from 'react-dom';
+import { v4 as uuid } from 'uuid';
+import {
+  addBlock,
+  changeBlock,
+  insertBlock,
+  blockHasValue,
+  getBlocksFieldname,
+  getBlocksLayoutFieldname,
+} from '@plone/volto/helpers/Blocks/Blocks';
+import { Transforms, Editor, Node } from 'slate';
+import { serializeNodesToText } from '@plone/volto-slate/editor/render';
+import omit from 'lodash/omit';
+import config from '@plone/volto/registry';
+
+// Full shadow copy of Volto 18's Volto block utility.
+// Actual customization: normalize the cursor returned by
+// mergeSlateWithBlockBackward so Slate React receives a text point.
+
+function fromEntries(pairs) {
+  const res = {};
+  pairs.forEach((p) => {
+    res[p[0]] = p[1];
+  });
+  return res;
+}
+
+// EEA customization: after Backspace merges Slate blocks, Volto 18 can keep
+// the cursor on an inline element path. Slate React needs a text leaf path.
+function normalizeCursorToTextPoint(editor, cursor) {
+  try {
+    const point = Editor.start(editor, cursor.anchor.path);
+    return { anchor: point, focus: point };
+  } catch {
+    return cursor;
+  }
+}
+
+export function mergeSlateWithBlockBackward(editor, prevBlock, event) {
+  // Merge the current block content into the previous block
+  // The current block content should be appended to the previous block
+  // and the cursor should be positioned at the start of what was the current block content
+
+  const prevValue = [...prevBlock.value];
+  const currentValue = [...editor.children];
+
+  const lastNode = prevValue[prevValue.length - 1];
+  const firstNode = currentValue[0];
+  let merged;
+  let cursor;
+
+  if (lastNode && firstNode && lastNode.type === firstNode.type) {
+    // If the last node of previous block and first node of current block have the same type,
+    // merge their children together
+    const mergedFirstNode = {
+      ...lastNode,
+      children: [...lastNode.children, ...firstNode.children],
+    };
+
+    merged = [
+      ...prevValue.slice(0, -1),
+      mergedFirstNode,
+      ...currentValue.slice(1),
+    ];
+
+    cursor = {
+      anchor: {
+        path: [prevValue.length - 1, lastNode.children.length],
+        offset: 0,
+      },
+      focus: {
+        path: [prevValue.length - 1, lastNode.children.length],
+        offset: 0,
+      },
+    };
+  } else {
+    // Otherwise, just append the current block content to the previous block
+    merged = [...prevValue, ...currentValue];
+    // Position cursor at the start of the merged content (where current block was inserted)
+    // The current block content starts at index prevValue.length in the merged array
+    cursor = {
+      anchor: {
+        path: [prevValue.length, 0],
+        offset: 0,
+      },
+      focus: {
+        path: [prevValue.length, 0],
+        offset: 0,
+      },
+    };
+  }
+
+  // Update the editor with the merged content
+  editor.children = merged;
+
+  // EEA customization: return a DOM-resolvable Slate selection.
+  return normalizeCursorToTextPoint(editor, cursor);
+}
+
+export function mergeSlateWithBlockForward(editor, nextBlock, event) {
+  // To work around current architecture limitations, read the value from next
+  // block. Replace it in the current editor (over which we have control), join
+  // with current block value, then use this result for next block, delete
+  // current block
+
+  const next = nextBlock?.value;
+  // Safeguard: if next block has no value or an empty value, there is nothing to merge
+  if (!Array.isArray(next) || next.length === 0) {
+    return;
+  }
+
+  // collapse the selection to its start point
+  Transforms.collapse(editor, { edge: 'end' });
+  Transforms.insertNodes(editor, next, {
+    at: Editor.end(editor, []),
+  });
+
+  Editor.deleteForward(editor, { unit: 'character' });
+}
+
+export function syncCreateSlateBlock(value) {
+  const id = uuid();
+  const block = {
+    '@type': 'slate',
+    value: JSON.parse(JSON.stringify(value)),
+    plaintext: serializeNodesToText(value),
+  };
+  return [id, block];
+}
+
+export function createImageBlock(url, index, props, intl) {
+  const { properties, onChangeField, onSelectBlock } = props;
+  const blocksFieldname = getBlocksFieldname(properties);
+  const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+
+  const currBlockId = properties.blocks_layout.items[index];
+  const currBlockHasValue = blockHasValue(properties.blocks[currBlockId]);
+  let id, newFormData;
+
+  if (currBlockHasValue) {
+    [id, newFormData] = addBlock(properties, 'image', index + 1, null, intl);
+    newFormData = changeBlock(newFormData, id, { '@type': 'image', url });
+  } else {
+    [id, newFormData] = insertBlock(properties, currBlockId, {
+      '@type': 'image',
+      url,
+    });
+  }
+
+  ReactDOM.unstable_batchedUpdates(() => {
+    onChangeField(blocksFieldname, newFormData[blocksFieldname]);
+    onChangeField(blocksLayoutFieldname, newFormData[blocksLayoutFieldname]);
+    onSelectBlock(id);
+  });
+}
+
+export const createAndSelectNewBlockAfter = (editor, blockValue, intl) => {
+  const blockProps = editor.getBlockProps();
+
+  const { onSelectBlock, properties, index, onChangeField } = blockProps;
+
+  const [blockId, formData] = addBlock(
+    properties,
+    'slate',
+    index + 1,
+    null,
+    intl,
+  );
+
+  const options = {
+    '@type': 'slate',
+    value: JSON.parse(JSON.stringify(blockValue)),
+    plaintext: serializeNodesToText(blockValue),
+  };
+
+  const newFormData = changeBlock(formData, blockId, options);
+
+  const blocksFieldname = getBlocksFieldname(properties);
+  const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+  // console.log('layout', blocksLayoutFieldname, newFormData);
+
+  ReactDOM.unstable_batchedUpdates(() => {
+    blockProps.saveSlateBlockSelection(blockId, 'start');
+    onChangeField(blocksFieldname, newFormData[blocksFieldname]);
+    onChangeField(blocksLayoutFieldname, newFormData[blocksLayoutFieldname]);
+    onSelectBlock(blockId);
+  });
+};
+
+export function getNextVoltoBlock(index, properties) {
+  // TODO: look for any next slate block
+  // join this block with previous block, if previous block is slate
+  const blocksFieldname = getBlocksFieldname(properties);
+  const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+
+  const blocks_layout = properties[blocksLayoutFieldname];
+
+  if (index === blocks_layout.items.length) return;
+
+  const nextBlockId = blocks_layout.items[index + 1];
+  const nextBlock = properties[blocksFieldname][nextBlockId];
+
+  return [nextBlock, nextBlockId];
+}
+
+export function getPreviousVoltoBlock(index, properties) {
+  // TODO: look for any prev slate block
+  if (index === 0) return;
+
+  const blocksFieldname = getBlocksFieldname(properties);
+  const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+
+  const blocks_layout = properties[blocksLayoutFieldname];
+  const prevBlockId = blocks_layout.items[index - 1];
+  const prevBlock = properties[blocksFieldname][prevBlockId];
+
+  return [prevBlock, prevBlockId];
+}
+
+// //check for existing img children
+// const checkContainImg = (elements) => {
+//   var check = false;
+//   elements.forEach((e) =>
+//     e.children.forEach((c) => {
+//       if (c && c.type && c.type === 'img') {
+//         check = true;
+//       }
+//     }),
+//   );
+//   return check;
+// };
+
+// //check for existing table children
+// const checkContainTable = (elements) => {
+//   var check = false;
+//   elements.forEach((e) => {
+//     if (e && e.type && e.type === 'table') {
+//       check = true;
+//     }
+//   });
+//   return check;
+// };
+
+/**
+ * The editor has the properties `dataTransferHandlers` (object) and
+ * `dataTransferFormatsOrder` and in `dataTransferHandlers` are functions which
+ * sometimes must call this function. Some types of data storeable in Slate
+ * documents can be and should be put into separate Volto blocks. The
+ * `deconstructToVoltoBlocks` function scans the contents of the Slate document
+ * and, through configured Volto block emitters, it outputs separate Volto
+ * blocks into the same Volto page form. The `deconstructToVoltoBlocks` function
+ * should be called only in key places where it is necessary.
+ *
+ * @example See the `src/editor/extensions/insertData.js` file.
+ *
+ * @param {Editor} editor The Slate editor object which should be deconstructed
+ * if possible.
+ *
+ * @returns {Promise}
+ */
+export function deconstructToVoltoBlocks(editor) {
+  // Explodes editor content into separate blocks
+  // If the editor has multiple top-level children, split the current block
+  // into multiple slate blocks. This will delete and replace the current
+  // block.
+  //
+  // It returns a promise that, when resolved, will pass a list of Volto block
+  // ids that were affected
+  //
+  // For the Volto blocks manipulation we do low-level changes to the context
+  // form state, as that ensures a better performance (no un-needed UI updates)
+
+  if (!editor.getBlockProps) return;
+
+  const blockProps = editor.getBlockProps();
+  const { slate } = config.settings;
+  const { voltoBlockEmiters } = slate;
+
+  return new Promise((resolve, reject) => {
+    if (!editor?.children) return;
+
+    if (editor.children.length === 1) {
+      return resolve([blockProps.block]);
+    }
+    const { properties, onChangeField, onSelectBlock } = editor.getBlockProps();
+    const blocksFieldname = getBlocksFieldname(properties);
+    const blocksLayoutFieldname = getBlocksLayoutFieldname(properties);
+
+    const { index } = blockProps;
+    let blocks = [];
+
+    // TODO: should use Editor.levels() instead of Node.children
+    const pathRefs = Array.from(Node.children(editor, [])).map(([, path]) =>
+      Editor.pathRef(editor, path),
+    );
+
+    for (const pathRef of pathRefs) {
+      // extra nodes are always extracted after the text node
+      let extras = voltoBlockEmiters
+        .map((emit) => emit(editor, pathRef))
+        .flat(1);
+
+      // The node might have been replaced with a Volto block
+      if (pathRef.current) {
+        const [childNode] = Editor.node(editor, pathRef.current);
+        if (childNode && !Editor.isEmpty(editor, childNode))
+          blocks.push(syncCreateSlateBlock([childNode]));
+      }
+      blocks = [...blocks, ...extras];
+    }
+
+    const blockids = blocks.map((b) => b[0]);
+
+    // TODO: add the placeholder block, because we remove it
+    // (when we remove the current block)
+
+    const blocksData = omit(
+      {
+        ...properties[blocksFieldname],
+        ...fromEntries(blocks),
+      },
+      blockProps.block,
+    );
+    const layoutData = {
+      ...properties[blocksLayoutFieldname],
+      items: [
+        ...properties[blocksLayoutFieldname].items.slice(0, index),
+        ...blockids,
+        ...properties[blocksLayoutFieldname].items.slice(index),
+      ].filter((id) => id !== blockProps.block),
+    };
+
+    // TODO: use onChangeFormData instead of this API style
+    ReactDOM.unstable_batchedUpdates(() => {
+      onChangeField(blocksFieldname, blocksData);
+      onChangeField(blocksLayoutFieldname, layoutData);
+      onSelectBlock(blockids[blockids.length - 1]);
+      // resolve(blockids);
+      // or rather this?
+      Promise.resolve().then(resolve(blockids));
+    });
+  });
+}

--- a/src/customizations/@plone/volto-slate/utils/volto-blocks.js.diff
+++ b/src/customizations/@plone/volto-slate/utils/volto-blocks.js.diff
@@ -1,0 +1,41 @@
+--- node_modules/@plone/volto-slate/src/utils/volto-blocks.js	2026-06-05 17:35:11.017650572 +0300
++++ src/addons/volto-eea-website-theme/src/customizations/@plone/volto-slate/utils/volto-blocks.js	2026-06-11 16:40:38.107968133 +0300
+@@ -13,6 +13,10 @@
+ import omit from 'lodash/omit';
+ import config from '@plone/volto/registry';
+ 
++// Full shadow copy of Volto 18's Volto block utility.
++// Actual customization: normalize the cursor returned by
++// mergeSlateWithBlockBackward so Slate React receives a text point.
++
+ function fromEntries(pairs) {
+   const res = {};
+   pairs.forEach((p) => {
+@@ -21,6 +25,17 @@
+   return res;
+ }
+ 
++// EEA customization: after Backspace merges Slate blocks, Volto 18 can keep
++// the cursor on an inline element path. Slate React needs a text leaf path.
++function normalizeCursorToTextPoint(editor, cursor) {
++  try {
++    const point = Editor.start(editor, cursor.anchor.path);
++    return { anchor: point, focus: point };
++  } catch {
++    return cursor;
++  }
++}
++
+ export function mergeSlateWithBlockBackward(editor, prevBlock, event) {
+   // Merge the current block content into the previous block
+   // The current block content should be appended to the previous block
+@@ -78,7 +93,8 @@
+   // Update the editor with the merged content
+   editor.children = merged;
+ 
+-  return cursor;
++  // EEA customization: return a DOM-resolvable Slate selection.
++  return normalizeCursorToTextPoint(editor, cursor);
+ }
+ 
+ export function mergeSlateWithBlockForward(editor, nextBlock, event) {


### PR DESCRIPTION
Fixes a Volto 18 Slate crash when deleting bold linked text.
The issue was caused by nested inline content (strong > link) where Slate could not resolve the DOM node because inline markup elements were rendered without Slate attributes. The fix renders those inline elements with the required attributes and tightens selection handling so Backspace does not treat the start of an inline node as the start of the whole block.