### PR TITLE
Fix betterleaks: Remove PASSWORD from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,1 @@
 JEST_USE_SETUP=OFF # Jest configuration variables: ON, OFF
-PASSWORD=test


### PR DESCRIPTION
Betterleaks detected `PASSWORD=test` in `.env` as a secret leak. Removing it to pass the betterleaks scan.

Refs #304517